### PR TITLE
Add endpoint suffix to the connection string

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -21,7 +21,13 @@ $storageKeyDetails = az storage account keys list --account-name $storageName --
 $storageKey = $storageKeyDetails[0].value
 echo "::add-mask::$storageKey"
 
-$storageConnectString = "DefaultEndpointsProtocol=https;AccountName=$storageName;AccountKey=$storageKey;EndpointSuffix=core.windows.net"
+$blobEndpoint = $storageDetails.primaryEndpoints.blob
+$uri = [System.Uri]$blobEndpoint
+$uriHost = $uri.Host
+$endpointSuffix = $uriHost.Substring($uriHost.IndexOf('.') + 1)
+$endpointSuffix = $endpointSuffix.Substring($endpointSuffix.IndexOf('.') + 1)
+
+$storageConnectString = "DefaultEndpointsProtocol=https;AccountName=$storageName;AccountKey=$storageKey;EndpointSuffix=$endpointSuffix"
 
 echo "Tagging storage account"
 $ignore = az tag create --resource-id $storageDetails.id --tags $packageTag $runnerOsTag $dateTag

--- a/setup.ps1
+++ b/setup.ps1
@@ -21,7 +21,7 @@ $storageKeyDetails = az storage account keys list --account-name $storageName --
 $storageKey = $storageKeyDetails[0].value
 echo "::add-mask::$storageKey"
 
-$storageConnectString = "DefaultEndpointsProtocol=https;AccountName=$storageName;AccountKey=$storageKey"
+$storageConnectString = "DefaultEndpointsProtocol=https;AccountName=$storageName;AccountKey=$storageKey;EndpointSuffix=core.windows.net"
 
 echo "Tagging storage account"
 $ignore = az tag create --resource-id $storageDetails.id --tags $packageTag $runnerOsTag $dateTag


### PR DESCRIPTION
Storage account URIs require the endpoint suffix. It is possible to have a custom suffix. To be compliant with how the connection string looks like from the portal and be able to extra the endpoint suffix in the tests for `DefaultAzureCredentials` that require a fully qualified URI I have augmented the setup action to create proper connection strings automatically